### PR TITLE
fix a small bug, initialize the S matrix

### DIFF
--- a/PYXAID2/runMD.py
+++ b/PYXAID2/runMD.py
@@ -247,7 +247,7 @@ def runMD(params):
 
                     as_sz = len(act_space)
                     H = CMATRIX(info["nk"]*as_sz, info["nk"]*as_sz )
-
+                    S = CMATRIX(info["nk"]*as_sz, info["nk"]*as_sz )
                     for ik1 in xrange(info["nk"]):
                         for ik2 in range(ik1, info["nk"]):
 


### PR DESCRIPTION
fix a small bug, initialize the S matrix in runMD.py. This sounds necessary, otherwise, line280 will terminate with error.